### PR TITLE
630:P2: Extract run_command to utils (#29)

### DIFF
--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -21,9 +21,7 @@ import logging
 import os
 import pathlib
 import re
-import shlex
 import stat
-import subprocess
 import sys
 import warnings
 from base64 import b64encode
@@ -49,6 +47,7 @@ from airflow.exceptions import AirflowConfigException, RemovedInAirflow4Warning
 from airflow.secrets import DEFAULT_SECRETS_SEARCH_PATH
 from airflow.task.weight_rule import WeightRule
 from airflow.utils import yaml
+from airflow.utils.command_runner import run_command as _run_command
 
 if TYPE_CHECKING:
     from airflow.api_fastapi.auth.managers.base_auth_manager import BaseAuthManager
@@ -135,18 +134,7 @@ def expand_env_var(env_var: str | None) -> str | None:
 
 def run_command(command: str) -> str:
     """Run command and returns stdout."""
-    process = subprocess.Popen(
-        shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True
-    )
-    output, stderr = (stream.decode(sys.getdefaultencoding(), "ignore") for stream in process.communicate())
-
-    if process.returncode != 0:
-        raise AirflowConfigException(
-            f"Cannot execute {command}. Error code is: {process.returncode}. "
-            f"Output: {output}, Stderr: {stderr}"
-        )
-
-    return output
+    return _run_command(command)
 
 
 def _default_config_file_path(file_name: str) -> str:

--- a/airflow-core/src/airflow/utils/command_runner.py
+++ b/airflow-core/src/airflow/utils/command_runner.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Utilities for running shell commands and capturing stdout."""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+import sys
+
+from airflow.exceptions import AirflowConfigException
+
+
+def run_command(command: str) -> str:
+    """Run command and returns stdout."""
+    process = subprocess.Popen(
+        shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True
+    )
+    output, stderr = (stream.decode(sys.getdefaultencoding(), "ignore") for stream in process.communicate())
+
+    if process.returncode != 0:
+        raise AirflowConfigException(
+            f"Cannot execute {command}. Error code is: {process.returncode}. "
+            f"Output: {output}, Stderr: {stderr}"
+        )
+
+    return output
+


### PR DESCRIPTION
Title 
Extract run_command helper into utils (#29)

Body

This change moves the run_command implementation out of configuration.py into airflow.utils.command_runner, and keeps configuration.run_command as a thin wrapper for the same public behavior. That reduces size and responsibility in configuration.py and makes the subprocess/AirflowConfigException logic easier to reuse and test in one place.

How to verify

Import paths for callers of run_command from airflow.configuration are unchanged.
On your machine: run targeted tests around configuration / secret interpolation if you have them (e.g. config unit tests via Breeze).