### PR TITLE
630:P2: Split get_airflow_health into component helpers (#27)

### DIFF
--- a/airflow-core/src/airflow/api/common/airflow_health.py
+++ b/airflow-core/src/airflow/api/common/airflow_health.py
@@ -26,31 +26,36 @@ HEALTHY = "healthy"
 UNHEALTHY = "unhealthy"
 
 
-def get_airflow_health() -> dict[str, Any]:
-    """Get the health for Airflow metadatabase, scheduler and triggerer."""
-    metadatabase_status = HEALTHY
-    latest_scheduler_heartbeat = None
-    latest_triggerer_heartbeat = None
-    latest_dag_processor_heartbeat = None
+def _check_scheduler_health() -> tuple[str, str | None, bool]:
+    """
+    Collect scheduler component health.
 
-    scheduler_status = UNHEALTHY
-    triggerer_status: str | None = UNHEALTHY
-    dag_processor_status: str | None = UNHEALTHY
-
+    Returns (status, latest_heartbeat_iso_or_none, metadatabase_reachable).
+    """
     try:
         latest_scheduler_job = SchedulerJobRunner.most_recent_job()
-
+        latest_scheduler_heartbeat = None
+        scheduler_status = UNHEALTHY
         if latest_scheduler_job:
             if latest_scheduler_job.latest_heartbeat:
                 latest_scheduler_heartbeat = latest_scheduler_job.latest_heartbeat.isoformat()
             if latest_scheduler_job.is_alive():
                 scheduler_status = HEALTHY
+        return scheduler_status, latest_scheduler_heartbeat, True
     except Exception:
-        metadatabase_status = UNHEALTHY
+        return UNHEALTHY, None, False
 
+
+def _check_triggerer_health() -> tuple[str | None, str | None, bool]:
+    """
+    Collect triggerer component health.
+
+    Returns (status, latest_heartbeat_iso_or_none, metadatabase_reachable).
+    """
     try:
         latest_triggerer_job = TriggererJobRunner.most_recent_job()
-
+        latest_triggerer_heartbeat = None
+        triggerer_status: str | None = UNHEALTHY
         if latest_triggerer_job:
             if latest_triggerer_job.latest_heartbeat:
                 latest_triggerer_heartbeat = latest_triggerer_job.latest_heartbeat.isoformat()
@@ -58,12 +63,21 @@ def get_airflow_health() -> dict[str, Any]:
                 triggerer_status = HEALTHY
         else:
             triggerer_status = None
+        return triggerer_status, latest_triggerer_heartbeat, True
     except Exception:
-        metadatabase_status = UNHEALTHY
+        return UNHEALTHY, None, False
 
+
+def _check_dag_processor_health() -> tuple[str | None, str | None, bool]:
+    """
+    Collect DAG processor component health.
+
+    Returns (status, latest_heartbeat_iso_or_none, metadatabase_reachable).
+    """
     try:
         latest_dag_processor_job = DagProcessorJobRunner.most_recent_job()
-
+        latest_dag_processor_heartbeat = None
+        dag_processor_status: str | None = UNHEALTHY
         if latest_dag_processor_job:
             if latest_dag_processor_job.latest_heartbeat:
                 latest_dag_processor_heartbeat = latest_dag_processor_job.latest_heartbeat.isoformat()
@@ -71,10 +85,28 @@ def get_airflow_health() -> dict[str, Any]:
                 dag_processor_status = HEALTHY
         else:
             dag_processor_status = None
+        return dag_processor_status, latest_dag_processor_heartbeat, True
     except Exception:
+        return UNHEALTHY, None, False
+
+
+def get_airflow_health() -> dict[str, Any]:
+    """Get the health for Airflow metadatabase, scheduler and triggerer."""
+    metadatabase_status = HEALTHY
+
+    scheduler_status, latest_scheduler_heartbeat, meta_ok = _check_scheduler_health()
+    if not meta_ok:
         metadatabase_status = UNHEALTHY
 
-    airflow_health_status = {
+    triggerer_status, latest_triggerer_heartbeat, meta_ok = _check_triggerer_health()
+    if not meta_ok:
+        metadatabase_status = UNHEALTHY
+
+    dag_processor_status, latest_dag_processor_heartbeat, meta_ok = _check_dag_processor_health()
+    if not meta_ok:
+        metadatabase_status = UNHEALTHY
+
+    return {
         "metadatabase": {"status": metadatabase_status},
         "scheduler": {
             "status": scheduler_status,
@@ -89,5 +121,3 @@ def get_airflow_health() -> dict[str, Any]:
             "latest_dag_processor_heartbeat": latest_dag_processor_heartbeat,
         },
     }
-
-    return airflow_health_status


### PR DESCRIPTION
## 630:P2: Lower cognitive complexity in get_airflow_health (#27)


SonarQube flagged get_airflow_health() for high cognitive complexity (python:S3776). The logic is unchanged: scheduler, triggerer, and DAG processor are still queried the same way, errors from those checks still mark the metadatabase as unhealthy, and the JSON structure returned to the health endpoint is the same.

This PR pulls each component’s check into a small helper (_check_scheduler_health, _check_triggerer_health, _check_dag_processor_health) so the top-level function only aggregates results. That should bring complexity under the project threshold without changing monitoring behavior.

How to verify

breeze run pytest airflow-core/tests/unit/api/common/test_airflow_health.py -xvs
Optional: re-run SonarQube and confirm python:S3776 is cleared for this function.
