### PR TITLE
630:P2: Defer warning hook setup to configure_warnings() (#30)

### DIFF
--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -189,8 +189,22 @@ def replace_showwarning(replacement):
     return original
 
 
-original_show_warning = replace_showwarning(custom_show_warning)
-atexit.register(partial(replace_showwarning, original_show_warning))
+_warnings_configuration_done = False
+
+
+def configure_warnings() -> None:
+    """
+    Install rich-based warning display and register cleanup on process exit.
+
+    Called from :func:`initialize` so that ``import airflow.settings`` does not
+    mutate global warning handlers as an import side effect.
+    """
+    global _warnings_configuration_done
+    if _warnings_configuration_done:
+        return
+    original_show_warning = replace_showwarning(custom_show_warning)
+    atexit.register(partial(replace_showwarning, original_show_warning))
+    _warnings_configuration_done = True
 
 
 def task_policy(task):
@@ -714,6 +728,7 @@ def import_local_settings():
 
 def initialize():
     """Initialize Airflow with all the settings from this file."""
+    configure_warnings()
     configure_vars()
     prepare_syspath_for_config_and_plugins()
     policy_mgr = get_policy_plugin_manager()


### PR DESCRIPTION
itle:
Defer Rich warning hook to configure_warnings() (#30)

Description:

Moves installation of the custom warnings.showwarning handler and its atexit restoration out of import time and into configure_warnings(), which initialize() calls first. A plain import airflow.settings no longer mutates global warning handlers; full Airflow startup behavior is unchanged when settings.initialize() runs (e.g. from airflow’s normal import path). The helper is idempotent so repeated initialize() calls are safe.

Verify: breeze run pytest airflow-core/tests/unit/core/test_settings.py -xvs

Closes #30