### PR TITLE
Document SQLAlchemy FunctionElement type attribute (S5806)

### DIFF
--- a/airflow-core/src/airflow/models/hitl.py
+++ b/airflow-core/src/airflow/models/hitl.py
@@ -43,7 +43,8 @@ class JSONExtract(FunctionElement):
     :meta: private
     """
 
-    type = String()
+    # SQLAlchemy FunctionElement requires this attribute name for the SQL return type.
+    type = String()  # noqa: A001  # NOSONAR S5806 — SQLAlchemy requires the name ``type``
     inherit_cache = True
 
     def __init__(self, column: ColumnElement[Any], key: str, **kwargs: dict[str, Any]) -> None:


### PR DESCRIPTION
Closes #NNN

## Summary
`JSONExtract` in `hitl.py` must keep a class attribute named `type` for SQLAlchemy’s `FunctionElement` API. Added an explicit comment and lint/Sonar suppressions so this is treated as a framework requirement, not accidental builtin shadowing.

## Verification
- `breeze run pytest airflow-core/tests/unit/models/ -k hitl -xvs` (or broader `tests/models/` if you prefer)
- `prek run ruff --all-files` (or your team’s lint command)

## Evidence
- Addresses Sonar **python: S5806** for this symbol by documenting that the name is required by SQLAlchemy; avoids renaming `type`, which would break the compiler integration.