### PR TITLE
Guard expand_env_var against unbounded/cyclic expansion

### DIFF
--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -124,6 +124,11 @@ def expand_env_var(env_var: None) -> None: ...
 def expand_env_var(env_var: str) -> str: ...
 
 
+# Legitimate nested expansion (e.g. A references B references a literal) is shallow; a
+# high iteration count almost always indicates a cyclic $VAR reference chain.
+_MAX_ENV_EXPANSION_ITERATIONS = 10
+
+
 def expand_env_var(env_var: str | None) -> str | None:
     """
     Expand (potentially nested) env vars.
@@ -133,7 +138,16 @@ def expand_env_var(env_var: str | None) -> str | None:
     """
     if not env_var or not isinstance(env_var, str):
         return env_var
+    original = env_var
+    iterations = 0
     while True:
+        iterations += 1
+        if iterations > _MAX_ENV_EXPANSION_ITERATIONS:
+            raise AirflowConfigException(
+                "Environment variable expansion did not stabilize after "
+                f"{_MAX_ENV_EXPANSION_ITERATIONS} iterations; "
+                f"possible circular reference (starting from {original!r})."
+            )
         interpolated = os.path.expanduser(os.path.expandvars(str(env_var)))
         if interpolated == env_var:
             return interpolated

--- a/airflow-core/tests/unit/core/test_configuration.py
+++ b/airflow-core/tests/unit/core/test_configuration.py
@@ -73,6 +73,13 @@ def restore_env():
         yield
 
 
+def test_expand_env_var_detects_circular_reference(monkeypatch):
+    monkeypatch.setenv("AIRFLOW_CIRC_A", "$AIRFLOW_CIRC_B")
+    monkeypatch.setenv("AIRFLOW_CIRC_B", "$AIRFLOW_CIRC_A")
+    with pytest.raises(AirflowConfigException, match="circular"):
+        expand_env_var("$AIRFLOW_CIRC_A")
+
+
 @pytest.fixture(scope="module", autouse=True)
 def restore_providers_manager_configuration():
     yield


### PR DESCRIPTION
Closes #NNN

## Summary
Added a maximum iteration cap to `expand_env_var()` in `configuration.py`. If expansion does not stabilize, raise `AirflowConfigException` with a message that points to a possible circular `$VAR` chain. Normal acyclic expansion is unchanged.

## Verification
- `breeze run pytest airflow-core/tests/unit/core/test_configuration.py::test_expand_env_var_detects_circular_reference -xvs.`
- `breeze run pytest airflow-core/tests/configuration/ -xvs` (if your tree uses that path; otherwise stick to `test_configuration.py`)

## Evidence
- New test uses a two-variable cycle and expects the new exception.
- Eliminates infinite hang on misconfigured env at startup.