### PR TITLE
Refactor: parse sync DB URLs with SQLAlchemy make_url

### DIFF
--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -53,7 +53,7 @@ from airflow._shared.timezones.timezone import (
     utc,
 )
 from airflow.configuration import AIRFLOW_HOME, conf
-from airflow.exceptions import AirflowInternalRuntimeError
+from airflow.exceptions import AirflowConfigException, AirflowInternalRuntimeError
 from airflow.logging_config import configure_logging
 from airflow.utils.orm_event_handlers import setup_event_handlers
 
@@ -247,16 +247,39 @@ def load_policy_plugins(pm: pluggy.PluginManager):
     pm.load_setuptools_entrypoints("airflow.policy")
 
 
-def _get_async_conn_uri_from_sync(sync_uri):
-    AIO_LIBS_MAPPING = {"sqlite": "aiosqlite", "postgresql": "asyncpg", "mysql": "aiomysql"}
-    """Mapping of sync scheme to async scheme."""
+# Primary SQL dialect (before any sync driver suffix, e.g. ``postgresql`` from
+# ``postgresql+psycopg2``) to the async driver Airflow uses when
+# ``sql_alchemy_conn_async`` is not set.
+_SYNC_SCHEME_TO_ASYNC_LIB: dict[str, str] = {
+    "sqlite": "aiosqlite",
+    "postgresql": "asyncpg",
+    "mysql": "aiomysql",
+}
 
-    scheme, rest = sync_uri.split(":", maxsplit=1)
-    scheme = scheme.split("+", maxsplit=1)[0]
-    aiolib = AIO_LIBS_MAPPING.get(scheme)
-    if aiolib:
-        return f"{scheme}+{aiolib}:{rest}"
-    return sync_uri
+
+def _get_async_conn_uri_from_sync(sync_uri: str) -> str:
+    """
+    Derive a default async SQLAlchemy URL from a synchronous connection URL.
+
+    Supported dialects are listed in ``_SYNC_SCHEME_TO_ASYNC_LIB``. Other URLs
+    are returned unchanged. Malformed URLs raise :class:`AirflowConfigException`.
+    """
+    from sqlalchemy.engine.url import make_url
+    from sqlalchemy.exc import ArgumentError
+
+    try:
+        parsed = make_url(sync_uri)
+    except ArgumentError as e:
+        raise AirflowConfigException(
+            f"Invalid database URL for async SQLAlchemy conversion: {sync_uri!r}"
+        ) from e
+
+    dialect = parsed.drivername.split("+", maxsplit=1)[0]
+    async_lib = _SYNC_SCHEME_TO_ASYNC_LIB.get(dialect)
+    if async_lib is None:
+        return sync_uri
+    new_drivername = f"{dialect}+{async_lib}"
+    return parsed.set(drivername=new_drivername).render_as_string(hide_password=False)
 
 
 def configure_vars():

--- a/airflow-core/tests/unit/core/test_settings.py
+++ b/airflow-core/tests/unit/core/test_settings.py
@@ -228,3 +228,32 @@ def test_sqlite_relative_path(value, expectation):
     ):
         with expectation:
             settings.configure_orm()
+
+
+class TestAsyncConnUriFromSync:
+    def test_postgresql_preserves_query_and_encoded_password(self):
+        from airflow.settings import _get_async_conn_uri_from_sync
+
+        sync_uri = "postgresql://user:p%40ss@host/dbname?sslmode=require"
+        async_uri = _get_async_conn_uri_from_sync(sync_uri)
+        assert "asyncpg" in async_uri
+        assert "sslmode=require" in async_uri
+        assert "p%40ss" in async_uri
+
+    def test_mysql_and_sqlite(self):
+        from airflow.settings import _get_async_conn_uri_from_sync
+
+        assert "+aiomysql" in _get_async_conn_uri_from_sync("mysql://user:pw@localhost/mydb")
+        assert "+aiosqlite" in _get_async_conn_uri_from_sync("sqlite:///tmp/airflow.db")
+
+    def test_unknown_dialect_unchanged(self):
+        from airflow.settings import _get_async_conn_uri_from_sync
+
+        uri = "oracle+cx_oracle://user:pass@host/sid"
+        assert _get_async_conn_uri_from_sync(uri) == uri
+
+    def test_invalid_uri_raises(self):
+        from airflow.settings import _get_async_conn_uri_from_sync
+
+        with pytest.raises(AirflowConfigException):
+            _get_async_conn_uri_from_sync("not a valid sqlalchemy url%%%")


### PR DESCRIPTION
Closes #NNN

## Summary
`_get_async_conn_uri_from_sync()` now uses `sqlalchemy.engine.url.make_url()` instead of string splitting. Dialect → async driver mapping is documented at module level; invalid URLs raise `AirflowConfigException`. Supported backends (sqlite / postgresql / mysql) keep the same async driver choice as before.

## Verification
- `breeze run pytest airflow-core/tests/unit/core/test_settings.py::TestAsyncConnUriFromSync -xvs`
- `breeze run pytest airflow-core/tests/unit/core/test_settings.py -xvs` (optional broader run)

## Evidence
- Safer handling of query strings and percent-encoding vs naive `split(":")`.
- Tests cover PostgreSQL + query params + encoded password, MySQL, SQLite, unknown dialect (unchanged), and invalid URL (clear error).