### PR TITLE
CSCI 630 P3: Design-pattern refactors (issues #63–#70)

### DIFF
--- a/airflow-core/src/airflow/cli/cli_parser.py
+++ b/airflow-core/src/airflow/cli/cli_parser.py
@@ -67,32 +67,7 @@ _CLI_COMMAND_LOAD_ERRORS: tuple[type[BaseException], ...] = (
     RuntimeError,
 )
 
-# AIRFLOW_PACKAGE_NAME is set when generating docs and we don't want to load provider commands when generating airflow-core CLI docs
-if not os.environ.get("AIRFLOW_PACKAGE_NAME", None):
-    providers_manager = ProvidersManager()
-    # Load CLI commands from providers
-    try:
-        for cli_function in providers_manager.cli_command_functions:
-            try:
-                airflow_commands.extend(cli_function())
-            except _CLI_COMMAND_LOAD_ERRORS as exc:
-                log.exception(
-                    "Failed to load CLI commands from provider function: %s (%s)",
-                    cli_function.__name__,
-                    type(exc).__name__,
-                )
-                log.error("Ensure all dependencies are met and try again.")
-                # Do not re-raise the exception since we want the CLI to still function for
-                # other commands.
-    except _CLI_COMMAND_LOAD_ERRORS as e:
-        log.warning(
-            "Failed to load CLI commands from providers (%s): %s",
-            type(e).__name__,
-            e,
-        )
-        # do not re-raise for the same reason as above
-
-    WARNING_TEMPLATE = """
+_WARNING_TEMPLATE_CLI = """
 Please define the 'cli' section in the 'get_provider_info' for custom {component} to avoid this warning.
 For community providers, please update to the version that support 'cli' section.
 For more details, see https://airflow.apache.org/docs/apache-airflow-providers/core-extensions/cli-commands.html
@@ -100,10 +75,40 @@ For more details, see https://airflow.apache.org/docs/apache-airflow-providers/c
 Providers with {component} missing 'cli' section in 'get_provider_info': {not_defined_cli_dict}
     """
 
-    # compat loading for older providers that define get_cli_commands methods on Executors
+_cli_extensions_loaded = False
+
+
+@cache
+def _providers_manager_for_cli() -> ProvidersManager:
+    return ProvidersManager()
+
+
+def _log_cli_extension_failure(
+    source: str, detail: str, exc: BaseException, guidance: str | None = None
+) -> None:
+    log.exception("Failed to load CLI commands from %s: %s (%s)", source, detail, type(exc).__name__)
+    log.error(guidance or "Ensure all dependencies are met and try again.")
+
+
+def _load_provider_cli_extension_handlers(commands: list[CLICommand]) -> None:
+    providers_manager = _providers_manager_for_cli()
     try:
-        # if there is any executor_provider not in cli_provider, we have to do compat loading
-        # we use without check to avoid actual loading in this check
+        for cli_function in providers_manager.cli_command_functions:
+            try:
+                commands.extend(cli_function())
+            except _CLI_COMMAND_LOAD_ERRORS as exc:
+                _log_cli_extension_failure("provider function", cli_function.__name__, exc)
+    except _CLI_COMMAND_LOAD_ERRORS as e:
+        log.warning(
+            "Failed to load CLI commands from providers (%s): %s",
+            type(e).__name__,
+            e,
+        )
+
+
+def _load_executor_compat_cli_extensions(commands: list[CLICommand]) -> None:
+    providers_manager = _providers_manager_for_cli()
+    try:
         executors_not_defined_cli = {
             executor_name: executor_provider
             for executor_name, executor_provider in providers_manager.executor_without_check
@@ -111,14 +116,13 @@ Providers with {component} missing 'cli' section in 'get_provider_info': {not_de
         }
         if executors_not_defined_cli:
             log.warning(
-                WARNING_TEMPLATE.format(
+                _WARNING_TEMPLATE_CLI.format(
                     component="executors", not_defined_cli_dict=str(executors_not_defined_cli)
                 )
             )
             from airflow.executors.executor_loader import ExecutorLoader
 
             for executor_name in ExecutorLoader.get_executor_names(validate_teams=False):
-                # Skip if the executor already has CLI commands defined via the 'cli' section in provider.yaml
                 if executor_name.module_path not in executors_not_defined_cli:
                     log.debug(
                         "Skipping loading for '%s' as it is defined in 'cli' section.",
@@ -128,21 +132,18 @@ Providers with {component} missing 'cli' section in 'get_provider_info': {not_de
 
                 try:
                     executor, _ = ExecutorLoader.import_executor_cls(executor_name)
-                    airflow_commands.extend(executor.get_cli_commands())
+                    commands.extend(executor.get_cli_commands())
                 except _CLI_COMMAND_LOAD_ERRORS as exc:
-                    log.exception(
-                        "Failed to load CLI commands from executor: %s (%s)",
-                        executor_name,
-                        type(exc).__name__,
+                    _log_cli_extension_failure(
+                        "executor",
+                        str(executor_name),
+                        exc,
+                        guidance=(
+                            "Ensure all dependencies are met and try again. If using a Celery based executor install "
+                            "a 3.3.0+ version of the Celery provider. If using a Kubernetes executor, install a "
+                            "7.4.0+ version of the CNCF provider"
+                        ),
                     )
-                    log.error(
-                        "Ensure all dependencies are met and try again. If using a Celery based executor install "
-                        "a 3.3.0+ version of the Celery provider. If using a Kubernetes executor, install a "
-                        "7.4.0+ version of the CNCF provider"
-                    )
-                    # Do not re-raise the exception since we want the CLI to still function for
-                    # other commands.
-
     except _CLI_COMMAND_LOAD_ERRORS as e:
         log.warning(
             "Failed to load CLI commands from executors that didn't define `get_cli_commands` in `.cli.definition` (%s): %s",
@@ -150,10 +151,10 @@ Providers with {component} missing 'cli' section in 'get_provider_info': {not_de
             e,
         )
 
-    # compat loading for older providers that define get_cli_commands methods on AuthManagers
+
+def _load_auth_manager_compat_cli_extensions(commands: list[CLICommand]) -> None:
+    providers_manager = _providers_manager_for_cli()
     try:
-        # if there is any auth_manager not in cli_provider, we have to do compat loading
-        # we use without check to avoid actual loading in this check
         auth_managers_not_defined_cli = {
             auth_manager_name: auth_manager_provider
             for auth_manager_name, auth_manager_provider in providers_manager.auth_manager_without_check
@@ -161,7 +162,7 @@ Providers with {component} missing 'cli' section in 'get_provider_info': {not_de
         }
         if auth_managers_not_defined_cli:
             log.warning(
-                WARNING_TEMPLATE.format(
+                _WARNING_TEMPLATE_CLI.format(
                     component="auth manager", not_defined_cli_dict=str(auth_managers_not_defined_cli)
                 )
             )
@@ -180,16 +181,9 @@ Providers with {component} missing 'cli' section in 'get_provider_info': {not_de
                 try:
                     auth_manager_cls = import_string(auth_manager_cls_path)
                     auth_manager = auth_manager_cls()
-                    airflow_commands.extend(auth_manager.get_cli_commands())
+                    commands.extend(auth_manager.get_cli_commands())
                 except _CLI_COMMAND_LOAD_ERRORS as exc:
-                    log.exception(
-                        "Failed to load CLI commands from auth manager: %s (%s)",
-                        auth_manager_cls_path,
-                        type(exc).__name__,
-                    )
-                    log.error("Ensure all dependencies are met and try again.")
-                    # Do not re-raise the exception since we want the CLI to still function for
-                    # other commands.
+                    _log_cli_extension_failure("auth manager", auth_manager_cls_path, exc)
     except _CLI_COMMAND_LOAD_ERRORS as e:
         log.warning(
             "Failed to load CLI commands from auth managers that didn't define `get_cli_commands` in `.cli.definition` (%s): %s",
@@ -197,16 +191,47 @@ Providers with {component} missing 'cli' section in 'get_provider_info': {not_de
             e,
         )
 
-ALL_COMMANDS_DICT: dict[str, CLICommand] = {sp.name: sp for sp in airflow_commands}
+
+def _cli_extension_chain(commands: list[CLICommand]) -> None:
+    """Chain of Responsibility: optional CLI sources applied in fixed order."""
+    for handler in (
+        _load_provider_cli_extension_handlers,
+        _load_executor_compat_cli_extensions,
+        _load_auth_manager_compat_cli_extensions,
+    ):
+        handler(commands)
 
 
-# Check if sub-commands are defined twice, which could be an issue.
-if len(ALL_COMMANDS_DICT) < len(airflow_commands):
-    dup = {k for k, v in Counter([c.name for c in airflow_commands]).items() if v > 1}
-    raise CliConflictError(
-        f"The following CLI {len(dup)} command(s) are defined more than once: {sorted(dup)}\n"
-        f"This can be due to a Provider redefining core airflow CLI commands."
-    )
+def _validate_cli_command_uniqueness(commands: list[CLICommand]) -> None:
+    all_commands_dict = {sp.name: sp for sp in commands}
+    if len(all_commands_dict) < len(commands):
+        dup = {k for k, v in Counter([c.name for c in commands]).items() if v > 1}
+        raise CliConflictError(
+            f"The following CLI {len(dup)} command(s) are defined more than once: {sorted(dup)}\n"
+            f"This can be due to a Provider redefining core airflow CLI commands."
+        )
+
+
+def ensure_cli_commands_loaded() -> None:
+    """
+    Lazy-load provider/executor/auth manager CLI extensions (virtual proxy).
+
+    Importing this module only registers core commands; extensions load when the CLI is built.
+    """
+    global _cli_extensions_loaded
+    if _cli_extensions_loaded:
+        return
+    # AIRFLOW_PACKAGE_NAME is set when generating docs — skip optional extensions (same as before).
+    if not os.environ.get("AIRFLOW_PACKAGE_NAME", None):
+        _cli_extension_chain(airflow_commands)
+    _validate_cli_command_uniqueness(airflow_commands)
+    _cli_extensions_loaded = True
+
+
+def get_all_commands_dict() -> dict[str, CLICommand]:
+    """Resolved command map (lazy: triggers extension loading on first use)."""
+    ensure_cli_commands_loaded()
+    return {sp.name: sp for sp in airflow_commands}
 
 
 class AirflowHelpFormatter(RichHelpFormatter):
@@ -221,7 +246,7 @@ class AirflowHelpFormatter(RichHelpFormatter):
             self._indent()
             subactions = action._get_subactions()
             action_subcommands, group_subcommands = partition(
-                lambda d: isinstance(ALL_COMMANDS_DICT[d.dest], GroupCommand), subactions
+                lambda d: isinstance(get_all_commands_dict()[d.dest], GroupCommand), subactions
             )
             yield Action([], f"\n{' ':{self._current_indent}}Groups", nargs=0)
             self._indent()
@@ -257,7 +282,7 @@ def get_parser(dag_parser: bool = False) -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="subcommand", metavar="GROUP_OR_COMMAND")
     subparsers.required = True
 
-    command_dict = DAG_CLI_DICT if dag_parser else ALL_COMMANDS_DICT
+    command_dict = DAG_CLI_DICT if dag_parser else get_all_commands_dict()
     for _, sub in sorted(command_dict.items()):
         _add_command(subparsers, sub)
     return parser

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -28,10 +28,9 @@ from base64 import b64encode
 from collections.abc import Callable
 from configparser import ConfigParser
 from copy import deepcopy
-from inspect import ismodule
 from io import StringIO
 from re import Pattern
-from typing import IO, TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING, Any, Protocol
 from urllib.parse import urlsplit
 
 from typing_extensions import overload
@@ -164,6 +163,37 @@ def _default_config_file_path(file_name: str) -> str:
     return os.path.join(templates_dir, file_name)
 
 
+class ConfigDescriptionSource(Protocol):
+    """Adapter target: a source of configuration schema/description data."""
+
+    def fetch(self) -> dict[str, dict[str, Any]]:
+        """Return option metadata as nested section dicts."""
+
+
+class FileConfigDescriptionAdapter:
+    """Adapts disk-backed core `config.yml` to the common description shape."""
+
+    def fetch(self) -> dict[str, dict[str, Any]]:
+        with open(_default_config_file_path("config.yml")) as config_file:
+            return yaml.safe_load(config_file)
+
+
+class ProvidersConfigDescriptionAdapter:
+    """Adapts provider manager metadata to the same description shape."""
+
+    def __init__(self, selected_provider: str | None) -> None:
+        self._selected_provider = selected_provider
+
+    def fetch(self) -> dict[str, dict[str, Any]]:
+        from airflow.providers_manager import ProvidersManager
+
+        merged: dict[str, dict[str, Any]] = {}
+        for provider, config in ProvidersManager().provider_configs:
+            if not self._selected_provider or provider == self._selected_provider:
+                merged.update(config)
+        return merged
+
+
 def retrieve_configuration_description(
     include_airflow: bool = True,
     include_providers: bool = True,
@@ -177,17 +207,116 @@ def retrieve_configuration_description(
     :param selected_provider: If specified, include selected provider only
     :return: Python dictionary containing configs & their info
     """
-    base_configuration_description: dict[str, dict[str, Any]] = {}
+    sources: list[ConfigDescriptionSource] = []
     if include_airflow:
-        with open(_default_config_file_path("config.yml")) as config_file:
-            base_configuration_description.update(yaml.safe_load(config_file))
+        sources.append(FileConfigDescriptionAdapter())
     if include_providers:
-        from airflow.providers_manager import ProvidersManager
-
-        for provider, config in ProvidersManager().provider_configs:
-            if not selected_provider or provider == selected_provider:
-                base_configuration_description.update(config)
+        sources.append(ProvidersConfigDescriptionAdapter(selected_provider))
+    base_configuration_description: dict[str, dict[str, Any]] = {}
+    for source in sources:
+        base_configuration_description.update(source.fetch())
     return base_configuration_description
+
+
+class _CustomConfigFileWriter:
+    """
+    Template Method for custom config file output: collection, optional transforms, render, write.
+
+    Keeps ``AirflowConfigParser.write_custom_config`` as thin orchestration.
+    """
+
+    def __init__(self, parser: AirflowConfigParser, modifications: ConfigModifications) -> None:
+        self._parser = parser
+        self._modifications = modifications
+
+    def write(
+        self,
+        file: IO[str],
+        comment_out_defaults: bool,
+        include_descriptions: bool,
+        extra_spacing: bool,
+    ) -> None:
+        output = self.collect_effective_options()
+        self.render_sections_to_file(
+            file,
+            output,
+            comment_out_defaults=comment_out_defaults,
+            include_descriptions=include_descriptions,
+            extra_spacing=extra_spacing,
+        )
+
+    def collect_effective_options(self) -> dict[str, list[tuple[str, str, bool, str]]]:
+        modifications = self._modifications
+        output: dict[str, list[tuple[str, str, bool, str]]] = {}
+        parser = self._parser
+
+        for section in parser._sections:  # type: ignore[attr-defined]
+            for option, orig_value in parser._sections[section].items():  # type: ignore[attr-defined]
+                key = (section.lower(), option.lower())
+                if key in modifications.remove:
+                    continue
+
+                mod_comment = ""
+                if key in modifications.rename:
+                    new_sec, new_opt = modifications.rename[key]
+                    effective_section = new_sec
+                    effective_option = new_opt
+                    mod_comment += f"# Renamed from {section}.{option}\n"
+                else:
+                    effective_section = section
+                    effective_option = option
+
+                value = orig_value
+                if key in modifications.default_updates:
+                    mod_comment += (
+                        f"# Default updated from {orig_value} to {modifications.default_updates[key]}\n"
+                    )
+                    value = modifications.default_updates[key]
+
+                default_value = parser.get_default_value(effective_section, effective_option, fallback="")
+                is_default = str(value) == str(default_value)
+                output.setdefault(effective_section.lower(), []).append(
+                    (effective_option, str(value), is_default, mod_comment)
+                )
+        return output
+
+    def render_sections_to_file(
+        self,
+        file: IO[str],
+        output: dict[str, list[tuple[str, str, bool, str]]],
+        *,
+        comment_out_defaults: bool,
+        include_descriptions: bool,
+        extra_spacing: bool,
+    ) -> None:
+        modifications = self._modifications
+        parser = self._parser
+
+        for section, options in output.items():
+            section_buffer = StringIO()
+            section_buffer.write(f"[{section}]\n")
+            if include_descriptions:
+                description = parser.configuration_description.get(section, {}).get("description", "")
+                if description:
+                    for line in description.splitlines():
+                        section_buffer.write(f"# {line}\n")
+                    section_buffer.write("\n")
+            for option, value_str, is_default, mod_comment in options:
+                key = (section.lower(), option.lower())
+                if key in modifications.default_updates and comment_out_defaults:
+                    section_buffer.write(f"# {option} = {value_str}\n")
+                else:
+                    if mod_comment:
+                        section_buffer.write(mod_comment)
+                    if is_default and comment_out_defaults:
+                        section_buffer.write(f"# {option} = {value_str}\n")
+                    else:
+                        section_buffer.write(f"{option} = {value_str}\n")
+                if extra_spacing:
+                    section_buffer.write("\n")
+            content = section_buffer.getvalue().strip()
+            if content:
+                file.write(f"{content}\n\n")
 
 
 class AirflowConfigParser(_SharedAirflowConfigParser):
@@ -347,62 +476,12 @@ class AirflowConfigParser(_SharedAirflowConfigParser):
         :param modifications: ConfigModifications instance with rename, remove, and default updates.
         """
         modifications = modifications or ConfigModifications()
-        output: dict[str, list[tuple[str, str, bool, str]]] = {}
-
-        for section in self._sections:  # type: ignore[attr-defined]  # accessing _sections from ConfigParser
-            for option, orig_value in self._sections[section].items():  # type: ignore[attr-defined]
-                key = (section.lower(), option.lower())
-                if key in modifications.remove:
-                    continue
-
-                mod_comment = ""
-                if key in modifications.rename:
-                    new_sec, new_opt = modifications.rename[key]
-                    effective_section = new_sec
-                    effective_option = new_opt
-                    mod_comment += f"# Renamed from {section}.{option}\n"
-                else:
-                    effective_section = section
-                    effective_option = option
-
-                value = orig_value
-                if key in modifications.default_updates:
-                    mod_comment += (
-                        f"# Default updated from {orig_value} to {modifications.default_updates[key]}\n"
-                    )
-                    value = modifications.default_updates[key]
-
-                default_value = self.get_default_value(effective_section, effective_option, fallback="")
-                is_default = str(value) == str(default_value)
-                output.setdefault(effective_section.lower(), []).append(
-                    (effective_option, str(value), is_default, mod_comment)
-                )
-
-        for section, options in output.items():
-            section_buffer = StringIO()
-            section_buffer.write(f"[{section}]\n")
-            if include_descriptions:
-                description = self.configuration_description.get(section, {}).get("description", "")
-                if description:
-                    for line in description.splitlines():
-                        section_buffer.write(f"# {line}\n")
-                    section_buffer.write("\n")
-            for option, value_str, is_default, mod_comment in options:
-                key = (section.lower(), option.lower())
-                if key in modifications.default_updates and comment_out_defaults:
-                    section_buffer.write(f"# {option} = {value_str}\n")
-                else:
-                    if mod_comment:
-                        section_buffer.write(mod_comment)
-                    if is_default and comment_out_defaults:
-                        section_buffer.write(f"# {option} = {value_str}\n")
-                    else:
-                        section_buffer.write(f"{option} = {value_str}\n")
-                if extra_spacing:
-                    section_buffer.write("\n")
-            content = section_buffer.getvalue().strip()
-            if content:
-                file.write(f"{content}\n\n")
+        _CustomConfigFileWriter(self, modifications).write(
+            file,
+            comment_out_defaults=comment_out_defaults,
+            include_descriptions=include_descriptions,
+            extra_spacing=extra_spacing,
+        )
 
     def _ensure_providers_config_loaded(self) -> None:
         """Ensure providers configurations are loaded."""
@@ -640,11 +719,9 @@ class AirflowConfigParser(_SharedAirflowConfigParser):
             ]
         }
 
-    def __setstate__(self, state) -> None:
-        """Restore the state of the object from a dictionary representation."""
-        self.__init__()  # type: ignore[misc]
-        config = state.pop("_sections")
-        self.read_dict(config)
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Restore pickled state (Memento) without re-running ``__init__`` / redundant config setup."""
+        self.__dict__.clear()
         self.__dict__.update(state)
 
 
@@ -661,16 +738,53 @@ def get_airflow_config(airflow_home: str) -> str:
     return expand_env_var(airflow_config_var)
 
 
+class ExpansionVariablesRegistry:
+    """
+    Registry/Builder for config template expansion variables.
+
+    Uses an explicit symbol list instead of scanning ``globals()``, so the interpolation contract is
+    reviewable and new module-level names do not accidentally alter expansion.
+    """
+
+    __slots__ = ("_symbol_names",)
+
+    def __init__(self, symbol_names: tuple[str, ...]) -> None:
+        self._symbol_names = symbol_names
+
+    def build(self) -> dict[str, Any]:
+        module = sys.modules[__name__]
+        result: dict[str, Any] = {
+            "FERNET_KEY": _SecretKeys.fernet_key,
+            "JWT_SECRET_KEY": _SecretKeys.jwt_secret_key,
+        }
+        for name in self._symbol_names:
+            if hasattr(module, name):
+                result[name] = getattr(module, name)
+        return result
+
+
+# Symbols considered for interpolation (non-callable module exports), resolved only if defined.
+_REGISTERED_EXPANSION_SYMBOLS: tuple[str, ...] = (
+    "log",
+    "ConfigType",
+    "ConfigOptionsDictType",
+    "ConfigSectionSourcesType",
+    "ConfigSourcesType",
+    "ENV_VAR_PREFIX",
+    "VALUE_NOT_FOUND_SENTINEL",
+    "ValueNotFound",
+    "AIRFLOW_HOME",
+    "AIRFLOW_CONFIG",
+    "TEST_DAGS_FOLDER",
+    "TEST_PLUGINS_FOLDER",
+    "SECRET_KEY",
+    "conf",
+    "secrets_backend_list",
+)
+
+
 def get_all_expansion_variables() -> dict[str, Any]:
-    return {
-        "FERNET_KEY": _SecretKeys.fernet_key,
-        "JWT_SECRET_KEY": _SecretKeys.jwt_secret_key,
-        **{
-            k: v
-            for k, v in globals().items()
-            if not k.startswith("_") and not callable(v) and not ismodule(v)
-        },
-    }
+    return ExpansionVariablesRegistry(_REGISTERED_EXPANSION_SYMBOLS).build()
 
 
 def _generate_fernet_key() -> str:

--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -325,34 +325,37 @@ def run_providers_custom_runtime_checks():
     _run_openlineage_runtime_check()
 
 
-class SkipDBTestsSession:
+_DB_DISABLED_SESSION_MESSAGE = (
+    "Your test accessed the DB but `_AIRFLOW_SKIP_DB_TESTS` is set.\n"
+    "Either make sure your test does not use database or mark the test with `@pytest.mark.db_test`\n"
+    "See https://github.com/apache/airflow/blob/main/contributing-docs/testing/unit_tests.rst#"
+    "best-practices-for-db-tests on how "
+    "to deal with it and consult examples."
+)
+
+
+class _DBDisabledSessionMeta(type):
+    """Routes class-level access to a single failure (Null Object for skipped DB tests)."""
+
+    def __getattr__(cls, name: str) -> Any:
+        if name.startswith("_"):
+            raise AttributeError(name)
+        raise AirflowInternalRuntimeError(_DB_DISABLED_SESSION_MESSAGE)
+
+
+class DBDisabledSession(metaclass=_DBDisabledSessionMeta):
     """
-    This fake session is used to skip DB tests when `_AIRFLOW_SKIP_DB_TESTS` is set.
+    Stand-in ``Session`` when DB tests are skipped: every interaction raises the same clear error.
 
     :meta private:
     """
 
-    def __init__(self):
-        raise AirflowInternalRuntimeError(
-            "Your test accessed the DB but `_AIRFLOW_SKIP_DB_TESTS` is set.\n"
-            "Either make sure your test does not use database or mark the test with `@pytest.mark.db_test`\n"
-            "See https://github.com/apache/airflow/blob/main/contributing-docs/testing/unit_tests.rst#"
-            "best-practices-for-db-tests on how "
-            "to deal with it and consult examples."
-        )
+    def __init__(self, *args, **kwargs):
+        raise AirflowInternalRuntimeError(_DB_DISABLED_SESSION_MESSAGE)
 
-    def remove(*args, **kwargs):
-        pass
 
-    def get_bind(
-        self,
-        mapper=None,
-        clause=None,
-        bind=None,
-        _sa_skip_events=None,
-        _sa_skip_for_implicit_returning=False,
-    ):
-        pass
+# Backward-compatible alias
+SkipDBTestsSession = DBDisabledSession
 
 
 def _is_sqlite_db_path_relative(sqla_conn_str: str) -> bool:
@@ -430,7 +433,7 @@ def configure_orm(disable_connection_pool=False, pool_class=None):
 
     if os.environ.get("_AIRFLOW_SKIP_DB_TESTS") == "true":
         # Skip DB initialization in unit tests, if DB tests are skipped
-        Session = SkipDBTestsSession
+        Session = DBDisabledSession
         engine = None
         return
     log.debug("Setting up DB connection pool (PID %s)", os.getpid())
@@ -480,9 +483,10 @@ def configure_orm(disable_connection_pool=False, pool_class=None):
         register_at_fork(after_in_child=clean_in_fork)
 
 
-def prepare_engine_args(disable_connection_pool=False, pool_class=None):
-    """Prepare SQLAlchemy engine args."""
-    DEFAULT_ENGINE_ARGS: dict[str, dict[str, Any]] = {
+class EngineArgsBuilder:
+    """Builder for SQLAlchemy engine kwargs (incremental, dialect-specific steps)."""
+
+    _DEFAULT_ENGINE_ARGS: dict[str, dict[str, Any]] = {
         "postgresql": (
             {
                 "insertmanyvalues_page_size": 10000,
@@ -495,73 +499,88 @@ def prepare_engine_args(disable_connection_pool=False, pool_class=None):
         )
     }
 
-    default_args = {}
-    for dialect, default in DEFAULT_ENGINE_ARGS.items():
-        if SQL_ALCHEMY_CONN.startswith(dialect):
-            default_args = default.copy()
-            break
+    def __init__(self, disable_connection_pool: bool = False, pool_class: Any = None) -> None:
+        self._disable_connection_pool = disable_connection_pool
+        self._pool_class = pool_class
 
-    engine_args: dict = conf.getjson("database", "sql_alchemy_engine_args", fallback=default_args)
+    def _dialect_defaults(self) -> dict[str, Any]:
+        default_args: dict[str, Any] = {}
+        for dialect, default in self._DEFAULT_ENGINE_ARGS.items():
+            if SQL_ALCHEMY_CONN.startswith(dialect):
+                default_args = default.copy()
+                break
+        return conf.getjson("database", "sql_alchemy_engine_args", fallback=default_args)
 
-    if pool_class:
-        # Don't use separate settings for size etc, only those from sql_alchemy_engine_args
-        engine_args["poolclass"] = pool_class
-    elif disable_connection_pool or not conf.getboolean("database", "SQL_ALCHEMY_POOL_ENABLED"):
-        engine_args["poolclass"] = NullPool
-        log.debug("settings.prepare_engine_args(): Using NullPool")
-    elif not SQL_ALCHEMY_CONN.startswith("sqlite"):
-        # Pool size engine args not supported by sqlite.
-        # If no config value is defined for the pool size, select a reasonable value.
-        # 0 means no limit, which could lead to exceeding the Database connection limit.
-        pool_size = conf.getint("database", "SQL_ALCHEMY_POOL_SIZE", fallback=5)
+    def _apply_pool_policy(self, engine_args: dict[str, Any]) -> None:
+        if self._pool_class:
+            # Don't use separate settings for size etc, only those from sql_alchemy_engine_args
+            engine_args["poolclass"] = self._pool_class
+        elif self._disable_connection_pool or not conf.getboolean("database", "SQL_ALCHEMY_POOL_ENABLED"):
+            engine_args["poolclass"] = NullPool
+            log.debug("settings.prepare_engine_args(): Using NullPool")
+        elif not SQL_ALCHEMY_CONN.startswith("sqlite"):
+            # Pool size engine args not supported by sqlite.
+            # If no config value is defined for the pool size, select a reasonable value.
+            # 0 means no limit, which could lead to exceeding the Database connection limit.
+            pool_size = conf.getint("database", "SQL_ALCHEMY_POOL_SIZE", fallback=5)
 
-        # The maximum overflow size of the pool.
-        # When the number of checked-out connections reaches the size set in pool_size,
-        # additional connections will be returned up to this limit.
-        # When those additional connections are returned to the pool, they are disconnected and discarded.
-        # It follows then that the total number of simultaneous connections
-        # the pool will allow is pool_size + max_overflow,
-        # and the total number of "sleeping" connections the pool will allow is pool_size.
-        # max_overflow can be set to -1 to indicate no overflow limit;
-        # no limit will be placed on the total number
-        # of concurrent connections. Defaults to 10.
-        max_overflow = conf.getint("database", "SQL_ALCHEMY_MAX_OVERFLOW", fallback=10)
+            # The maximum overflow size of the pool.
+            # When the number of checked-out connections reaches the size set in pool_size,
+            # additional connections will be returned up to this limit.
+            # When those additional connections are returned to the pool, they are disconnected and discarded.
+            # It follows then that the total number of simultaneous connections
+            # the pool will allow is pool_size + max_overflow,
+            # and the total number of "sleeping" connections the pool will allow is pool_size.
+            # max_overflow can be set to -1 to indicate no overflow limit;
+            # no limit will be placed on the total number
+            # of concurrent connections. Defaults to 10.
+            max_overflow = conf.getint("database", "SQL_ALCHEMY_MAX_OVERFLOW", fallback=10)
 
-        # The DB server already has a value for wait_timeout (number of seconds after
-        # which an idle sleeping connection should be killed). Since other DBs may
-        # co-exist on the same server, SQLAlchemy should set its
-        # pool_recycle to an equal or smaller value.
-        pool_recycle = conf.getint("database", "SQL_ALCHEMY_POOL_RECYCLE", fallback=1800)
+            # The DB server already has a value for wait_timeout (number of seconds after
+            # which an idle sleeping connection should be killed). Since other DBs may
+            # co-exist on the same server, SQLAlchemy should set its
+            # pool_recycle to an equal or smaller value.
+            pool_recycle = conf.getint("database", "SQL_ALCHEMY_POOL_RECYCLE", fallback=1800)
 
-        # Check connection at the start of each connection pool checkout.
-        # Typically, this is a simple statement like "SELECT 1", but may also make use
-        # of some DBAPI-specific method to test the connection for liveness.
+            # Check connection at the start of each connection pool checkout.
+            # Typically, this is a simple statement like "SELECT 1", but may also make use
+            # of some DBAPI-specific method to test the connection for liveness.
+            # More information here:
+            # https://docs.sqlalchemy.org/en/14/core/pooling.html#disconnect-handling-pessimistic
+            pool_pre_ping = conf.getboolean("database", "SQL_ALCHEMY_POOL_PRE_PING", fallback=True)
+
+            log.debug(
+                "settings.prepare_engine_args(): Using pool settings. pool_size=%d, max_overflow=%d, "
+                "pool_recycle=%d, pid=%d",
+                pool_size,
+                max_overflow,
+                pool_recycle,
+                os.getpid(),
+            )
+            engine_args["pool_size"] = pool_size
+            engine_args["pool_recycle"] = pool_recycle
+            engine_args["pool_pre_ping"] = pool_pre_ping
+            engine_args["max_overflow"] = max_overflow
+
+    def _apply_mysql_isolation(self, engine_args: dict[str, Any]) -> None:
+        # The default isolation level for MySQL (REPEATABLE READ) can introduce inconsistencies when
+        # running multiple schedulers, as repeated queries on the same session may read from stale snapshots.
+        # 'READ COMMITTED' is the default value for PostgreSQL.
         # More information here:
-        # https://docs.sqlalchemy.org/en/14/core/pooling.html#disconnect-handling-pessimistic
-        pool_pre_ping = conf.getboolean("database", "SQL_ALCHEMY_POOL_PRE_PING", fallback=True)
+        # https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html
+        if SQL_ALCHEMY_CONN.startswith("mysql"):
+            engine_args["isolation_level"] = "READ COMMITTED"
 
-        log.debug(
-            "settings.prepare_engine_args(): Using pool settings. pool_size=%d, max_overflow=%d, "
-            "pool_recycle=%d, pid=%d",
-            pool_size,
-            max_overflow,
-            pool_recycle,
-            os.getpid(),
-        )
-        engine_args["pool_size"] = pool_size
-        engine_args["pool_recycle"] = pool_recycle
-        engine_args["pool_pre_ping"] = pool_pre_ping
-        engine_args["max_overflow"] = max_overflow
+    def build(self) -> dict[str, Any]:
+        engine_args = self._dialect_defaults()
+        self._apply_pool_policy(engine_args)
+        self._apply_mysql_isolation(engine_args)
+        return engine_args
 
-    # The default isolation level for MySQL (REPEATABLE READ) can introduce inconsistencies when
-    # running multiple schedulers, as repeated queries on the same session may read from stale snapshots.
-    # 'READ COMMITTED' is the default value for PostgreSQL.
-    # More information here:
-    # https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html
-    if SQL_ALCHEMY_CONN.startswith("mysql"):
-        engine_args["isolation_level"] = "READ COMMITTED"
 
-    return engine_args
+def prepare_engine_args(disable_connection_pool=False, pool_class=None):
+    """Prepare SQLAlchemy engine args."""
+    return EngineArgsBuilder(disable_connection_pool, pool_class).build()
 
 
 def dispose_orm(do_log: bool = True):

--- a/airflow-core/tests/unit/core/test_configuration.py
+++ b/airflow-core/tests/unit/core/test_configuration.py
@@ -2047,3 +2047,38 @@ def test_ensure_fernet_is_generated(tmp_path, monkeypatch: pytest.MonkeyPatch):
 
     assert airflow.configuration._SecretKeys.fernet_key
     assert airflow.configuration._SecretKeys.fernet_key != "None"
+
+
+def test_get_all_expansion_variables_ignores_unregistered_module_attributes():
+    """Regression: expansion keys are explicit; random new module attrs must not alter interpolation dict."""
+    import airflow.configuration as c
+
+    keys_before = set(c.get_all_expansion_variables().keys())
+    setattr(c, "DUMMY_P3_EXPANSION_ATTR", "should_not_appear_in_expansion")
+    try:
+        keys_after = set(c.get_all_expansion_variables().keys())
+        assert "DUMMY_P3_EXPANSION_ATTR" not in keys_after
+        assert keys_before == keys_after
+    finally:
+        delattr(c, "DUMMY_P3_EXPANSION_ATTR")
+
+
+def test_airflow_config_parser_unpickle_avoids_rerunning_init(monkeypatch: pytest.MonkeyPatch):
+    import pickle
+
+    from airflow.configuration import AirflowConfigParser
+
+    init_count = 0
+    orig_init = AirflowConfigParser.__init__
+
+    def counting_init(self, *args, **kwargs):
+        nonlocal init_count
+        init_count += 1
+        return orig_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(AirflowConfigParser, "__init__", counting_init)
+    parser = AirflowConfigParser()
+    assert init_count == 1
+    roundtrip = pickle.loads(pickle.dumps(parser))
+    assert init_count == 1
+    assert isinstance(roundtrip, AirflowConfigParser)

--- a/airflow-core/tests/unit/core/test_settings.py
+++ b/airflow-core/tests/unit/core/test_settings.py
@@ -257,3 +257,13 @@ class TestAsyncConnUriFromSync:
 
         with pytest.raises(AirflowConfigException):
             _get_async_conn_uri_from_sync("not a valid sqlalchemy url%%%")
+
+
+def test_db_disabled_session_null_object_fails_consistently():
+    from airflow.exceptions import AirflowInternalRuntimeError
+    from airflow.settings import DBDisabledSession
+
+    with pytest.raises(AirflowInternalRuntimeError, match="_AIRFLOW_SKIP_DB_TESTS"):
+        DBDisabledSession.remove()
+    with pytest.raises(AirflowInternalRuntimeError, match="_AIRFLOW_SKIP_DB_TESTS"):
+        DBDisabledSession()


### PR DESCRIPTION
## Summary

Implements GitHub issues **#63–#70** with small, localized refactors: explicit expansion registry, config description adapters, template-method writer, memento pickle restore, engine-args builder, DB-disabled null session, lazy CLI loading, and a chain-style CLI extension pipeline.

## Issues

- Closes #63
- Closes #64
- Closes #65
- Closes #66
- Closes #67
- Closes #68
- Closes #69
- Closes #70

## Verification

Run targeted tests (from repo root, with Breeze per project docs):

```bash
breeze run pytest airflow-core/tests/unit/core/test_configuration.py::test_get_all_expansion_variables_ignores_unregistered_module_attributes airflow-core/tests/unit/core/test_configuration.py::test_airflow_config_parser_unpickle_avoids_rerunning_init airflow-core/tests/unit/core/test_settings.py::test_db_disabled_session_null_object_fails_consistently -xvs
breeze run pytest airflow-core/tests/unit/cli/test_cli_parser.py -xvs
```