### PR TITLE
630:P3: Replace isinstance chain with singledispatch Composite in CLI parser (#62)

### DIFF
--- a/airflow-core/src/airflow/cli/cli_parser.py
+++ b/airflow-core/src/airflow/cli/cli_parser.py
@@ -30,7 +30,7 @@ import os
 from argparse import Action
 from collections import Counter
 from collections.abc import Iterable
-from functools import cache
+from functools import cache, singledispatch
 from typing import TYPE_CHECKING
 
 import lazy_object_proxy
@@ -275,6 +275,26 @@ def _sort_args(args: Iterable[Arg]) -> Iterable[Arg]:
     yield from sorted(optional, key=lambda x: get_long_option(x).lower())
 
 
+@singledispatch
+def _configure_command(sub: object, sub_proc: argparse.ArgumentParser) -> None:
+    raise AirflowException("Invalid command definition.")
+
+
+@_configure_command.register(ActionCommand)
+def _(sub: ActionCommand, sub_proc: argparse.ArgumentParser) -> None:
+    for arg in _sort_args(sub.args):
+        arg.add_to_parser(sub_proc)
+    sub_proc.set_defaults(func=sub.func)
+
+
+@_configure_command.register(GroupCommand)
+def _(sub: GroupCommand, sub_proc: argparse.ArgumentParser) -> None:
+    sub_subparsers = sub_proc.add_subparsers(dest="subcommand", metavar="COMMAND")
+    sub_subparsers.required = True
+    for command in sorted(sub.subcommands, key=lambda x: x.name):
+        _add_command(sub_subparsers, command)
+
+
 def _add_command(subparsers: argparse._SubParsersAction, sub: CLICommand) -> None:
     if isinstance(sub, ActionCommand) and sub.hide:
         sub_proc = subparsers.add_parser(sub.name, epilog=sub.epilog)
@@ -283,24 +303,4 @@ def _add_command(subparsers: argparse._SubParsersAction, sub: CLICommand) -> Non
             sub.name, help=sub.help, description=sub.description or sub.help, epilog=sub.epilog
         )
     sub_proc.formatter_class = LazyRichHelpFormatter
-
-    if isinstance(sub, GroupCommand):
-        _add_group_command(sub, sub_proc)
-    elif isinstance(sub, ActionCommand):
-        _add_action_command(sub, sub_proc)
-    else:
-        raise AirflowException("Invalid command definition.")
-
-
-def _add_action_command(sub: ActionCommand, sub_proc: argparse.ArgumentParser) -> None:
-    for arg in _sort_args(sub.args):
-        arg.add_to_parser(sub_proc)
-    sub_proc.set_defaults(func=sub.func)
-
-
-def _add_group_command(sub: GroupCommand, sub_proc: argparse.ArgumentParser) -> None:
-    subcommands = sub.subcommands
-    sub_subparsers = sub_proc.add_subparsers(dest="subcommand", metavar="COMMAND")
-    sub_subparsers.required = True
-    for command in sorted(subcommands, key=lambda x: x.name):
-        _add_command(sub_subparsers, command)
+    _configure_command(sub, sub_proc)

--- a/airflow-core/tests/unit/cli/test_cli_parser.py
+++ b/airflow-core/tests/unit/cli/test_cli_parser.py
@@ -607,6 +607,16 @@ class TestCli:
                 action_cmd.name, help=action_cmd.help, description=action_cmd.help, epilog=action_cmd.epilog
             )
 
+    @pytest.mark.non_db_test_override
+    def test_configure_command_invalid_type_raises(self):
+        """_configure_command base dispatch must raise AirflowException for unknown types."""
+        from airflow.exceptions import AirflowException
+
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        with pytest.raises(AirflowException, match="Invalid command definition"):
+            cli_parser._configure_command(object(), subparsers)
+
 
 # We need to run it from sources with PYTHONPATH, not command line tool,
 # because we need to make sure that we have providers configured from source provider.yaml files


### PR DESCRIPTION
## Summary
- Replaces the `isinstance(sub, GroupCommand)` / `elif isinstance(sub, ActionCommand)` / `else: raise` chain in `_add_command` with a `@singledispatch` function `_configure_command`.
- Each command type registers its own handler; the `@singledispatch` base raises `AirflowException` for unknown types.
- Adding a new command type now requires only a new `@_configure_command.register` — no edit to `_add_command`.

## Design pattern
Composite (Structural) via Python's `functools.singledispatch`. Because `ActionCommand` and `GroupCommand` are `NamedTuple`s, singledispatch is the idiomatic way to achieve type-polymorphic dispatch without modifying the data types.

## Verification
- Added `test_configure_command_invalid_type_raises` to verify the default dispatch raises.
- Full `test_cli_parser.py` non-DB suite passes.
- `ruff check` clean.

closes: #62

---

##### Was generative AI tooling used to co-author this PR?

- [ ] No