### PR TITLE
630:P3: Separate pure validators from config migration in _validators (#61)

### DIFF
--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -66,6 +66,9 @@ ConfigOptionsDictType = dict[str, ConfigType]
 ConfigSectionSourcesType = dict[str, str | tuple[str, str]]
 ConfigSourcesType = dict[str, ConfigSectionSourcesType]
 
+# Type alias for config validators: zero-argument callables that raise on invalid config.
+ConfigValidator = Callable[[], None]
+
 ENV_VAR_PREFIX = "AIRFLOW__"
 
 _DEPRECATED_LOG_FILENAME_TEMPLATE_LEGACY = (
@@ -358,14 +361,18 @@ class AirflowConfigParser(_SharedAirflowConfigParser):
         self._providers_configuration_loaded = False
 
     @property
-    def _validators(self) -> list[Callable[[], None]]:
-        """Overring _validators from shared base class to add core-specific validators."""
+    def _validators(self) -> list[ConfigValidator]:
+        """Override _validators from shared base class with core-specific pure validators."""
         return [
             self._validate_sqlite3_version,
             self._validate_enums,
             self._validate_deprecated_values,
-            self._upgrade_postgres_metastore_conn,
         ]
+
+    def validate(self) -> None:
+        """Run validators then apply post-validation config migrations."""
+        super().validate()
+        self._upgrade_postgres_metastore_conn()
 
     @property
     def _lookup_sequence(self) -> list[Callable]:

--- a/airflow-core/tests/unit/core/test_configuration.py
+++ b/airflow-core/tests/unit/core/test_configuration.py
@@ -2082,3 +2082,22 @@ def test_airflow_config_parser_unpickle_avoids_rerunning_init(monkeypatch: pytes
     roundtrip = pickle.loads(pickle.dumps(parser))
     assert init_count == 1
     assert isinstance(roundtrip, AirflowConfigParser)
+
+
+def test_validators_list_contains_only_pure_validators():
+    """_validators must not contain _upgrade_postgres_metastore_conn (a mutator, not a validator)."""
+    from airflow.configuration import conf
+
+    validator_names = [v.__name__ for v in conf._validators]
+    assert "_upgrade_postgres_metastore_conn" not in validator_names
+
+
+def test_validate_still_calls_upgrade_postgres_metastore_conn():
+    """validate() must still invoke _upgrade_postgres_metastore_conn after the refactor."""
+    from unittest.mock import patch
+
+    from airflow.configuration import AirflowConfigParser, conf
+
+    with patch.object(AirflowConfigParser, "_upgrade_postgres_metastore_conn") as mock_upgrade:
+        conf.validate()
+    mock_upgrade.assert_called_once()


### PR DESCRIPTION
## Summary
- Removes `_upgrade_postgres_metastore_conn` from `_validators` (it mutates config state, violating the validator contract).
- Adds a `validate()` override in `AirflowConfigParser` that calls `super().validate()` (pure validators) then `_upgrade_postgres_metastore_conn()` explicitly.
- Adds `ConfigValidator = Callable[[], None]` type alias, making the validator contract visible.

## Design pattern
Strategy (Behavioral) — explicit separation of validation vs. migration. Each entry in `_validators` is independently callable and side-effect-free. The mutation is promoted to an explicit lifecycle step.

## Verification
- Added `test_validators_list_contains_only_pure_validators` and `test_validate_still_calls_upgrade_postgres_metastore_conn`.
- Full non-DB `test_configuration.py` suite passes (121 passed, 8 skipped).
- `ruff check` clean.

closes: #61

---

##### Was generative AI tooling used to co-author this PR?

- [ ] No